### PR TITLE
Added double cancellation

### DIFF
--- a/examples/http-api-server/js/app.js
+++ b/examples/http-api-server/js/app.js
@@ -1,27 +1,41 @@
 angular.module('myApp', [])
-.directive('ensureUnique', ['$http', '$timeout', function($http, $timeout) {
+.directive('ensureUnique', ['$http', '$timeout', '$q', function ($http, $timeout, $q) {
   var checking = null;
+  var canceler = null;
   return {
     require: 'ngModel',
     link: function(scope, ele, attrs, c) {
-      scope.$watch(attrs.ngModel, function(newVal) {
-        if (!checking) {
-          checking = $timeout(function() {
-            $http({
-              method: 'POST',
-              url: '/api/check/' + attrs.ensureUnique,
-              data: {'username': c.$modelValue} // this does not work
-            }).success(function(data, status, headers, cfg) {
-              c.$setValidity('unique', data.isUnique);
-              checking = null;
-            }).error(function(data, status, headers, cfg) {
-              checking = null;
-            });
-          }, 500);
+      scope.$watch(attrs.ngModel, function (newVal) {
+        if (checking) {
+          //Cancel pending request
+          $timeout.cancel(checking);
         }
+        checking = $timeout(function () {
+
+          if (canceler) {
+            //Cancel executing request
+            canceler.resolve();
+          }
+          canceler = $q.defer();
+
+          $http({
+            method: 'POST',
+            url: '/api/check/' + attrs.ensureUnique,
+            data: { 'username': newValue },
+            timeout: canceler.promise
+          }).success(function(data, status, headers, cfg) {
+            c.$setValidity('unique', data.isUnique);
+            checking = null;
+            canceler = null;
+          }).error(function(data, status, headers, cfg) {
+            //NB request cancellation appears here too
+            checking = null;
+            canceler = null;
+          });
+        }, 500);
       });
     }
-  }
+  };
 }])
 /*
 .directive('ngFocus', [function() {


### PR DESCRIPTION
Added timeout cancellation instead of not-executing during pending call, corrected reference to newVal. This causes locally pending requests to be re-created.
Added execution cancellation, this allows executing request to be cancelled while performing new request.

I did not verify the url part nor the actual request.
